### PR TITLE
Fixed : PyFFI xml fringe behaviors

### DIFF
--- a/pyffi/formats/nif/__init__.py
+++ b/pyffi/formats/nif/__init__.py
@@ -489,10 +489,11 @@ class NifFormat(FileFormat):
             if value is None:
                 self._value = None
             else:
-                if not isinstance(value, self._template):
-                    raise TypeError(
-                        'expected an instance of %s but got instance of %s'
-                        % (self._template, value.__class__))
+                if self._template != None:
+                    if not isinstance(value, self._template):
+                        raise TypeError(
+                            'expected an instance of %s but got instance of %s'
+                            % (self._template, value.__class__))
                 self._value = value
 
         def get_size(self, data=None):
@@ -542,11 +543,11 @@ class NifFormat(FileFormat):
                     return
             # other case: look up the link and check the link type
             block = data._block_dct[block_index]
-            if isinstance(block, self._template):
-                self.set_value(block)
-            else:
-                #raise TypeError('expected an instance of %s but got instance of %s'%(self._template, block.__class__))
-                logging.getLogger("pyffi.nif.ref").warn(
+            self.set_value(block)
+            if self._template != None:
+                if not isinstance(block, self._template):
+                    #raise TypeError('expected an instance of %s but got instance of %s'%(self._template, block.__class__))
+                    logging.getLogger("pyffi.nif.ref").warn(
                     "Expected an %s but got %s: ignoring reference."
                     % (self._template, block.__class__))
 
@@ -614,10 +615,11 @@ class NifFormat(FileFormat):
             if value is None:
                 self._value = None
             else:
-                if not isinstance(value, self._template):
-                    raise TypeError(
-                        'expected an instance of %s but got instance of %s'
-                        % (self._template, value.__class__))
+                if self._template != None:
+                    if not isinstance(value, self._template):
+                        raise TypeError(
+                            'expected an instance of %s but got instance of %s'
+                            % (self._template, value.__class__))
                 self._value = weakref.ref(value)
 
         def __str__(self):

--- a/pyffi/object_models/xml/struct_.py
+++ b/pyffi/object_models/xml/struct_.py
@@ -349,6 +349,8 @@ class StructBase(GlobalNode, metaclass=_MetaStructBase):
             # read the attribute
             attr_value = getattr(self, "_%s_value_" % attr.name)
             attr_value.arg = rt_arg
+            if hasattr(attr, "type_"):
+                attr_value._elementType = attr.type_
             attr_value.read(stream, data)
             ### UNCOMMENT FOR DEBUGGING WHILE READING
             #print("* %s.%s" % (self.__class__.__name__, attr.name)) # debug


### PR DESCRIPTION
## Wrong result when choosing between different types

When applying a condition to choose between different options to parse an array attribute, the option can be between different embedded data types in arrays that have the same name.

In this specific case, the PyFFI parser didn't reply with the right result but did reply with the embedded type of the first choice. This was due to the embedded type handling being done beforehand.

The fist commit fixes this behavior by retrieving the right option's embedded type and setting the actual result embedded type to the retrieved value. It first however checks for the existence of such value, in case the data isn't an array to begin with.
## Optional attribute "template" treated as mandatory

The "template" attribute, used in nif.xml to handle Ptr and Ref target type check, was specified as optional in the official PyFFI documentation. However, it was required for PyFFI to work. The second commit aims to fix this inconsistency.

It does so by checking if the _template attribute is set before attempting to compare the target against the template's description. If the template is defined and the target doesn't match the description, then the checker throws an error as usual. Otherwise, the checker validates the data.
