### PR TITLE
Fix ExtraVectorsFlags not being set even though data populated.

### DIFF
--- a/pyffi/formats/nif/__init__.py
+++ b/pyffi/formats/nif/__init__.py
@@ -4711,8 +4711,7 @@ class NifFormat(FileFormat):
                 this function.
             """
 
-            warnings.warn("use NifFormat.NiNode.send_bones_to_bind_position",
-                          DeprecationWarning)
+            warnings.warn("use NifFormat.NiNode.send_bones_to_bind_position", DeprecationWarning)
 
             if not self.is_skin():
                 return
@@ -6138,9 +6137,7 @@ class NifFormat(FileFormat):
 
             return zip(self.data.normals, tangents, bitangents)
 
-        def update_tangent_space(
-            self, as_extra=None,
-            vertexprecision=3, normalprecision=3):
+        def update_tangent_space(self, as_extra=None, vertexprecision=3, normalprecision=3):
             """Recalculate tangent space data.
 
             :param as_extra: Whether to store the tangent space data as extra data
@@ -6151,27 +6148,18 @@ class NifFormat(FileFormat):
             """
             # check that self.data exists and is valid
             if not isinstance(self.data, NifFormat.NiTriBasedGeomData):
-                raise ValueError(
-                    'cannot update tangent space of a geometry with %s data'
-                    %(self.data.__class__ if self.data else 'no'))
+                raise ValueError('cannot update tangent space of a geometry with %s data'
+                                 %(self.data.__class__ if self.data else 'no'))
 
             verts = self.data.vertices
             norms = self.data.normals
             if len(self.data.uv_sets) > 0:
-                uvs   = self.data.uv_sets[0]
+                uvs = self.data.uv_sets[0]
             else:
-                # no uv sets so no tangent space
-                # we clear the tangents space flag just
-                # happens in Fallout NV
-                # meshes/architecture/bouldercity/arcadeendl.nif
-                # (see issue #3218751)
-                #self.data.num_uv_sets &= ~4096
-                #self.data.bs_num_uv_sets &= ~4096
-                self.data.extra_vectors_flags = 0
                 # This is an error state and the mesh part should not be included in the exported nif.
-                # Rather alert the user to fix the offending part.
-                warnings.warn("Part of the exported mesh has Extra Vectors Flags applied without a material or uv set",
-                              DeprecationWarning)
+                # happens in Fallout NV meshes/architecture/bouldercity/arcadeendl.nif
+                self.data.extra_vectors_flags = 0
+                warnings.warn("Attempting to export mesh without uv data", DeprecationWarning)
                 return
 
             # check that shape has norms and uvs
@@ -6341,9 +6329,9 @@ class NifFormat(FileFormat):
                 extra.binary_data = bytes(binarydata)
             else:
                 # set tangent space flag
+                self.data.extra_vectors_flags = 16
                 # XXX used to be 61440
-                # XXX from Sid Meier's Railroad & Fallout 3 nifs, 4096 is
-                # XXX sufficient?
+                # XXX from Sid Meier's Railroad
                 self.data.tangents.update_size()
                 self.data.bitangents.update_size()
                 for vec, data_tans in zip(tan, self.data.tangents):
@@ -6354,6 +6342,8 @@ class NifFormat(FileFormat):
                     data_bins.x = vec.x
                     data_bins.y = vec.y
                     data_bins.z = vec.z
+                    
+                
 
         # ported from nifskope/skeleton.cpp:spSkinPartition
         def update_skin_partition(self,


### PR DESCRIPTION
# Scope

As from Pull request #15 , the `Num UV Sets` flag from the `NiGeometryData` object switched from a bitflags type to an enum, and changes were made accordingly to the PyFFI file format interface.

This flag handles the `Tangents` and `Bitangents` members existence in the object, and could take a value &-able with 16 to show that the members should exist, and any other otherwise.
# Issue

A problem was found where an `UV Set` was added and the `tangents`/`bitangents` were automatically recalculated. However, the data was never saved to the file.
# Solution

This change handled the case in which UV sets didn't exist by setting the new enum to 0. However, it didn't handle the case when an UV value was added.

The pull request solve this case by setting the flag to 16[`Tangents_Bitangents`] when an UV_set is added. This way, the tangents and bitangents can be computed and stored in the object, and it will be written in the file down the line.
# Extra information

The structure and expected data of the `UV Sets` member was described here : http://niftools.sourceforge.net/forum/viewtopic.php?f=10&t=321

As PyFFI seems to only use the first UV set, it may be an incomplete feature that might need fixing later.
