### PR TITLE
Get tests working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 .idea/
 venv/
+.cache/
+docs-sphinx/_build/

--- a/README.rst
+++ b/README.rst
@@ -18,32 +18,55 @@ Python library for processing block structured binary files:
 
 Download
 --------
-
-Get PyFFI from
-`Github <https://github.com/niftools/pyffi/releases>`_,
+Get PyFFI from `Github <https://github.com/niftools/pyffi/releases>`_,
 or install it with::
 
     easy_install -U PyFFI
 
 or::
+
     pip3 install PyFFI
 
+Developing
+----------
 To get the latest (but possibly unstable) code, clone PyFFI from its
 `Git repository <http://github.com/niftools/pyffi>`_::
 
     git clone --recursive git://github.com/niftools/pyffi.git
+    virtualenv -p python3 venv
+    source venv/bin/activate
+    pip install -r requirements-dev.txt
 
 Be sure to use the --recursive flag to ensure that you also get all
 of the submodules.
 
-If you wish to
-code on PyFFI and send your contributions back upstream, get a `github
-account <https://github.com/signup/free>`_ and `fork PyFFI
+If you wish to code on PyFFI and send your contributions back upstream,
+get a `github account <https://github.com/signup/free>`_ and `fork PyFFI
 <http://help.github.com/fork-a-repo/>`_.
+
+Testing
+-------
+We love tests, it helps guarantee that things keep working they way
+they should. You can run them yourself with the following::
+
+    source venv/bin/activate
+    nosetest -v test
+
+or::
+    source venv/bin/activate
+    py.test -v tests
+
+Documentation
+-------------
+All our documentation is written in ReST and can generated into HTML,
+LaTeX, PDF and more thanks to Sphinx. You can generate it yourself::
+
+    source venv/bin/activate
+    cd docs-sphinx
+    make html
 
 Examples
 --------
-
 * The `Blender NIF Plugin
   <https://github.com/niftools/blender_nif_plugin>`_
 
@@ -56,7 +79,6 @@ Examples
 
 Questions? Suggestions?
 -----------------------
-
 * Open an issue at the `issue tracker
   <https://github.com/niftools/pyffi/issues>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ get a `github account <https://github.com/signup/free>`_ and `fork PyFFI
 
 Testing
 -------
-We love tests, it helps guarantee that things keep working they way
+We love tests, they help guarantee that things keep working they way
 they should. You can run them yourself with the following::
 
     source venv/bin/activate
@@ -58,7 +58,7 @@ or::
 
 Documentation
 -------------
-All our documentation is written in ReST and can generated into HTML,
+All our documentation is written in ReST and can be generated into HTML,
 LaTeX, PDF and more thanks to Sphinx. You can generate it yourself::
 
     source venv/bin/activate

--- a/pyffi/spells/nif/optimize.py
+++ b/pyffi/spells/nif/optimize.py
@@ -508,7 +508,7 @@ class SpellOptimizeGeometry(pyffi.spells.nif.NifSpell):
         # recalculate tangent space (only if the branch already exists)
         if (branch.find(block_name=b'Tangent space (binormal & tangent vectors)',
                         block_type=NifFormat.NiBinaryExtraData)
-            or (data.num_uv_sets & 61440)):
+                or (data.num_uv_sets & 61440) or (data.extra_vectors_flags & 16)):
             self.toaster.msg("recalculating tangent space")
             branch.update_tangent_space()
 

--- a/pyffi/spells/nif/optimize.py
+++ b/pyffi/spells/nif/optimize.py
@@ -508,8 +508,7 @@ class SpellOptimizeGeometry(pyffi.spells.nif.NifSpell):
         # recalculate tangent space (only if the branch already exists)
         if (branch.find(block_name=b'Tangent space (binormal & tangent vectors)',
                         block_type=NifFormat.NiBinaryExtraData)
-            or (data.num_uv_sets & 61440)
-            or (data.bs_num_uv_sets & 61440)):
+            or (data.num_uv_sets & 61440)):
             self.toaster.msg("recalculating tangent space")
             branch.update_tangent_space()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+nose
+pdbpp
+pytest
+sphinx


### PR DESCRIPTION
- get tests working again
- use industry standard requirements-dev.txt 
- instructions on how to run tests
- additional entries to gitignore 
- updated the readme

The removal of bs_num_uv_sets is required to get the prefix/suffix test working again. Apparently bs_num_uv_sets was removed everywhere in the code... but there. Someone didn't run the test-suite. ;)

Here is the link to where it was removed in code to follow updates to nif.xml
https://github.com/niftools/pyffi/pull/15