### PR TITLE
Improve/Clean sphinx related code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,7 @@ import sys, os
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 
-on_rtd = os.getenv('READTHEDOCS') == 'True'
-
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # General configuration
 # ---------------------

--- a/pyffi/utils/__init__.py
+++ b/pyffi/utils/__init__.py
@@ -44,7 +44,7 @@
 import os
 from distutils.cmd import Command
 
-class BuildDoc(Command):
+class BuildDoc(Command): # pragma: no cover
     """
     Distutils command to stop setup.py from throwing errors
     if sphinx is not installed
@@ -63,7 +63,7 @@ class BuildDoc(Command):
         return
     
     def run(self):
-        print("Sphinx is not installed")
+        raise ModuleNotFoundError("Sphinx is not installed")
 
 def walk(top, topdown=True, onerror=None, re_filename=None):
     """A variant of os.walk() which also works if top is a file instead of a


### PR DESCRIPTION
@niftools/pyffi-reviewer 

# Overview
Add some of the improvements mentioned in #46 that wasn't implemented before the merge.

- Change BuildDocs from print into raise exception
So that it fails the travis build when the docs aren't buildable
- Tell coverage not to cover BuildDoc class
The BuildDoc class isn't required to be documented.
- Remove sphinx conf.py test code
- Update sphinx conf.py paths

## Fixes Known Issues
None

## Documentation
No BuildDoc coverage

## Testing
Nothing important changed, all code should be working fine.

### Manual
`python -m pip uninstall sphinx
python setup.py build_docs`

### Automated
No new errors were created.

## Additional Information
Please do not merge this request until I say so please. I wish to see if I can fix some sphinx build errors first.
Do tell me what you would like improved/fixed/remove!