### PR TITLE
Switch from GitHub Pages to Read the Docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,6 @@ script:
 after_success:
   - coveralls
   - python setup.py sdist bdist_wheel
-  - python setup.py build_docs -a
 
 notifications:
     email: false
-
-deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $github_token
-  local_dir: build/sphinx/html
-  on:
-    branch: develop
-    python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 PyFFI
 =====
-.. image:: https://img.shields.io/travis/niftools/pyffi/develop.svg?label=Linux%20Build
+.. image:: https://img.shields.io/travis/niftools/pyffi/develop.svg?label=Linux%20Build&logo=travis
     :target: https://travis-ci.org/niftools/pyffi
 
-.. image:: https://img.shields.io/appveyor/ci/neomonkeus/pyffi/develop.svg?label=Windows%20Build
+.. image:: https://img.shields.io/appveyor/ci/neomonkeus/pyffi/develop.svg?label=Windows%20Build&logo=appveyor
     :target: https://ci.appveyor.com/project/neomonkeus/pyffi
 
 .. image:: https://img.shields.io/coveralls/github/niftools/pyffi/develop.svg?label=Coverage


### PR DESCRIPTION
@niftools/pyffi-reviewer 

# Overview
Stops deploying documentation to GitHub pages

## Additional Information
- [Read the Docs documentation](https://docs.readthedocs.io/en/latest)


- [x] [Create accout](https://readthedocs.org/accounts/signup/)
- [x] [Connect account](https://readthedocs.org/accounts/social/connections/)
- [x] [Import Project](https://readthedocs.org/dashboard/import/?)
- [x] [Setup Project](https://readthedocs.org/dashboard/pyffi/edit/)
    - Settings:
        - [x] Description: `PyFFI is a Python library for processing block structured files.`
        - [x] Programming Language: `Python`
        - [x] Tags: `niftools, pyffi, fileformat, nif, cgf, binary, interface, stripify`
    - Advanced Settings:
        - [x] Install Project: ✅ 
        - [x] Requirements file: `./requirements-dev.txt`
        - [x] Default Version: `develop`
        - [x] Python interpreter: `CPython 3.x`
    - Versions:
        - [x] develop: ✅ 
        - [x] master: ✅ 
    - Domains: Two things can happen here. You have have an url like `http://pyffi.niftools.org` or `http://docs.niftools.org/project/pyffi/`
    -  [x] Maintainers: Remember to set maintainers
    -  [x] Integrations: Make sure a GitHub incoming webhook is setup properly!

Big checklist but it all I could come up with to make sure you understood everything.

Reasons why:

1. You don't want to give Travis GitHub access tokens.
2. Internationalisation
3. Multiple versions.

Also, I add logos to Build Badges
I will be doing this for blender_nif_plugin as well.