### PR TITLE
Fix setup.py missing package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ params = dict(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     packages=PACKAGES,
+    package_data=PACKAGE_DATA,
     scripts=SCRIPTS,
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
@niftools/pyffi-reviewer 

# Overview
setup.py is not including the package data

## Fixes Known Issues
n\a

## Documentation
[Overview of updates to documentation]

## Testing
[Overview of testing required to ensure functionality is correctly implemented]

### Manual
[Order steps to manually verify updates are working correctly]

### Automated
[List of tests run, updated or added to avoid future regressions]

## Additional Information
Caused by  #53 update which didn't reconnect the package_data attribute

