### PR TITLE
Python 3.7 support

### DIFF
--- a/pyffi/formats/cgf/__init__.py
+++ b/pyffi/formats/cgf/__init__.py
@@ -1842,9 +1842,9 @@ chunk size mismatch when reading %s at 0x%08X
                 for face in self.faces:
                     yield face.v_0, face.v_1, face.v_2
             elif self.indices_data:
-                it = iter(self.indices_data.indices)
-                while True:
-                   yield next(it), next(it), next(it)
+                inds = self.indices_data.indices
+                for i in range(0, len(inds), 3):
+                   yield inds[i], inds[i+1], inds[i+2]
 
         def get_material_indices(self):
             """Generator for all materials (per triangle)."""

--- a/pyffi/formats/nif/__init__.py
+++ b/pyffi/formats/nif/__init__.py
@@ -1973,6 +1973,28 @@ class NifFormat(FileFormat):
                        for row in self.as_list())
 
     class Vector3:
+                
+        def assign(self, vec):
+            """ Set this vector to values from another object that supports iteration or x,y,z properties """
+            # see if it is an iterable
+            try:
+                self.x = vec[0]
+                self.y = vec[1]
+                self.z = vec[2]
+            except:
+                if hasattr(vec, "x"):
+                    self.x = vec.x
+                if hasattr(vec, "y"):
+                    self.y = vec.y
+                if hasattr(vec, "z"):
+                    self.z = vec.z
+                
+        def __iter__(self):
+            # just a convenience so we can do: x,y,z = Vector3()
+            yield self.x
+            yield self.y
+            yield self.z
+        
         def as_list(self):
             return [self.x, self.y, self.z]
 

--- a/pyffi/object_models/xml/__init__.py
+++ b/pyffi/object_models/xml/__init__.py
@@ -101,13 +101,13 @@ class MetaFileFormat(pyffi.object_models.MetaFileFormat):
             # which takes care of the class creation
             cls.logger.debug("Parsing %s and generating classes."
                              % xml_file_name)
-            start = time.clock()
+            start = time.time()
             try:
                 parser.parse(xml_file)
             finally:
                 xml_file.close()
             cls.logger.debug("Parsing finished in %.3f seconds."
-                             % (time.clock() - start))
+                             % (time.time() - start))
 
 
 class FileFormat(pyffi.object_models.FileFormat, metaclass=MetaFileFormat):

--- a/pyffi/object_models/xml/enum.py
+++ b/pyffi/object_models/xml/enum.py
@@ -95,7 +95,7 @@ class _MetaEnumBase(type):
             cls.__i += 1
             return (cls._enumkeys[cls.__i-1], cls._enumvalues[cls.__i-1])
         else:
-            raise StopIteration
+            return
 
     def __getitem__(cls, key):
         if key in cls._enumkeys:

--- a/pyffi/object_models/xml/enum.py
+++ b/pyffi/object_models/xml/enum.py
@@ -40,7 +40,6 @@
 import logging
 import struct
 
-from pyffi.object_models import FileFormat as snakeCase
 from pyffi.object_models.xml.basic import BasicBase
 from pyffi.object_models.editable import EditableComboBox
 
@@ -84,7 +83,7 @@ class _MetaEnumBase(type):
 
         # set enum values as class attributes
         for item, value in zip(cls._enumkeys, cls._enumvalues):
-            setattr(cls, "".join(snakeCase.name_parts(item)), value)
+            setattr(cls, item, value)
 
     def __iter__(cls):
         cls.__i = 0

--- a/pyffi/object_models/xsd/__init__.py
+++ b/pyffi/object_models/xsd/__init__.py
@@ -520,7 +520,7 @@ class MetaFileFormat(pyffi.object_models.MetaFileFormat):
 
             # parse the XSD file
             cls.logger.debug("Parsing %s and generating classes." % xsdfilename)
-            start = time.clock()
+            start = time.time()
             try:
                 # create nodes for every element in the XSD tree
                 schema = Tree.node_factory(
@@ -535,7 +535,7 @@ class MetaFileFormat(pyffi.object_models.MetaFileFormat):
             # generate attributes
             schema.attribute_walker(cls)
             cls.logger.debug("Parsing finished in %.3f seconds."
-                             % (time.clock() - start))
+                             % (time.time() - start))
 
 class Type(object):
     _node = None


### PR DESCRIPTION
@niftools/pyffi-reviewer 

# Overview
Replaces expressions that are deprecated in 3.7 by stuff that works in all versions. Also adds small enhancements / fixes.

## Fixes Known Issues
none

## Documentation
none

## Testing
none

### Manual
none

### Automated
none

## Additional Information
none

