### PR TITLE
Toaster dump fixes

### DIFF
--- a/pyffi/spells/__init__.py
+++ b/pyffi/spells/__init__.py
@@ -3,7 +3,7 @@
 ==================================================
 
 .. note::
-   
+
    This module is based on wz's NifTester module, although
    nothing of wz's original code is left in this module.
 
@@ -24,7 +24,7 @@ For format specific spells, refer to the corresponding module.
 
 .. toctree::
    :maxdepth: 2
-   
+
    cgf
    dds
    kfm
@@ -67,13 +67,13 @@ be used for this purpose.
    :show-inheritance:
    :members:
    :undoc-members:
-   
+
 
 .. autoclass:: SpellGroupParallelBase
    :show-inheritance:
    :members:
    :undoc-members:
-   
+
 
 .. autoclass:: SpellGroupSeriesBase
    :show-inheritance:
@@ -149,6 +149,9 @@ import re  # for regex parsing (--skip, --only)
 import shlex  # shlex.split for parsing option lists in ini files
 import subprocess
 import tempfile
+
+import sys  # for sys.exc_info
+import traceback # for traceback.print_exception
 
 import pyffi  # for pyffi.__version__
 import pyffi.object_models  # pyffi.object_models.FileFormat
@@ -528,7 +531,7 @@ def SpellGroupSeries(*args):
                 {"SPELLCLASSES": args,
                  "SPELLNAME":
                      " | ".join(spellclass.SPELLNAME for spellclass in args),
-                 "READONLY": 
+                 "READONLY":
                       all(spellclass.READONLY for spellclass in args)})
 
 
@@ -539,7 +542,7 @@ def SpellGroupParallel(*args):
                 {"SPELLCLASSES": args,
                  "SPELLNAME":
                      " & ".join(spellclass.SPELLNAME for spellclass in args),
-                 "READONLY": 
+                 "READONLY":
                       all(spellclass.READONLY for spellclass in args)})
 
 class SpellApplyPatch(Spell):
@@ -551,7 +554,7 @@ class SpellApplyPatch(Spell):
         """There is no need to read the whole file, so we apply the patch
         already at inspection stage, and stop the spell process by returning
         ``False``.
-    
+
         :return: ``False``
         :rtype: ``bool``
         """
@@ -1205,7 +1208,7 @@ class Toaster(object):
         # is much more verbose by default
 
         pause = self.options.get("pause", False)
-        
+
         # do not ask for confirmation (!= cli default)
         interactive = self.options.get("interactive", False)
 
@@ -1326,12 +1329,12 @@ class Toaster(object):
 
             # create spell instance
             spell = self.spellclass(toaster=self, data=data, stream=stream)
-            
+
             # inspect the spell instance
             if spell._datainspect() and spell.datainspect():
                 # read the full file
                 data.read(stream)
-                
+
                 # cast the spell on the data tree
                 spell.recurse()
 
@@ -1347,7 +1350,10 @@ class Toaster(object):
         except Exception as expt:
             self.files_failed.add(stream.name)
             self.logger.error("FAILED ON {0} - with the follow exception".format(stream.name))
-            self.logger.error("EXPT MSG : " + str(expt))
+            self.logger.error("EXPT MSG:")
+            exc_info = sys.exc_info()
+            traceback.print_exception(*exc_info)
+            del exc_info
             self.logger.error("If you were running a spell that came with PyFFI")
             self.logger.error("Please report this issue - https://github.com/niftools/pyffi/issues")
             # if raising test errors, reraise the exception

--- a/pyffi/spells/nif/dump.py
+++ b/pyffi/spells/nif/dump.py
@@ -367,8 +367,8 @@ class SpellExportPixelData(NifSpell):
         head, tail = ntpath.split(texture_filename)
         root, ext = ntpath.splitext(tail)
         # for linux: make paths case insensitive by converting to lower case
-        head = head.lower().decode('utf8')
-        root = root.lower().decode('utf8')
+        head = head.lower().decode("utf8", "ignore")
+        root = root.lower().decode("utf8", "ignore")
         # XXX following is disabled because not all textures in Bully
         # XXX actually have this form; use "-a textures" for this game
         # make relative path for Bully SE

--- a/pyffi/spells/nif/dump.py
+++ b/pyffi/spells/nif/dump.py
@@ -408,6 +408,7 @@ class SpellExportPixelData(NifSpell):
         """Save pixeldata as dds file, using the specified filename."""
         self.toaster.msg("found pixel data (format %i)"
                          % pixeldata.pixel_format)
+        stream = None
         try:
             stream = self.get_toast_pixeldata_stream(texture_filename)
             if stream:

--- a/pyffi/spells/nif/dump.py
+++ b/pyffi/spells/nif/dump.py
@@ -136,7 +136,7 @@ def dumpAttr(attr):
         return tohex(attr, 4)
     else:
         return str(attr)
-    
+
 class SpellDumpAll(NifSpell):
     """Dump the whole NIF file."""
 
@@ -196,7 +196,7 @@ class SpellDumpTex(NifSpell):
             if len(textures) > 0:
                 for n, tex in enumerate (textures):
                     self.toaster.msg('%i: %s' % (n, tex))
-            else: 
+            else:
                 self.toaster.msg('BSShaderTextureSet has no Textures')
             return False
         else:
@@ -220,7 +220,7 @@ class SpellHtmlReport(NifSpell):
         # enter every branch
         # (the base method is called in branch entry)
         return True
-        
+
     def branchentry(self, branch):
         # check if this branch must be checked, if not, recurse further
         if not NifSpell._branchinspect(self, branch):
@@ -230,15 +230,15 @@ class SpellHtmlReport(NifSpell):
         if not reports:
             # start a new report for this block type
             row = "<tr>"
-            row += "<th>%s</th>" % "file" 
-            row +=  "<th>%s</th>" % "id" 
+            row += "<th>%s</th>" % "file"
+            row +=  "<th>%s</th>" % "id"
             for attr in branch._get_filtered_attribute_list(data=self.data):
                 row += ("<th>%s</th>"
                         % escape(attr.displayname, self.ENTITIES))
             row += "</tr>"
             reports = [row]
             self.toaster.reports_per_blocktype[blocktype] = reports
-        
+
         row = "<tr>"
         row += "<td>%s</td>" % escape(self.stream.name)
         row += "<td>%s</td>" % escape("0x%08X" % id(branch), self.ENTITIES)
@@ -277,10 +277,10 @@ class SpellHtmlReport(NifSpell):
     def browser(cls, htmlstr):
         """Display html in the default web browser without creating a
         temp file.
-        
+
         Instantiates a trivial http server and calls webbrowser.open
         with a URL to retrieve html from that server.
-        """    
+        """
         class RequestHandler(http.server.BaseHTTPRequestHandler):
             def do_GET(self):
                 bufferSize = 1024*1024
@@ -289,7 +289,7 @@ class SpellHtmlReport(NifSpell):
 
         server = http.server.HTTPServer(('127.0.0.1', 0), RequestHandler)
         webbrowser.open('http://127.0.0.1:%s' % server.server_port)
-        server.handle_request()           
+        server.handle_request()
 
 class SpellExportPixelData(NifSpell):
     """Export embedded images as DDS files. If the toaster's
@@ -367,8 +367,8 @@ class SpellExportPixelData(NifSpell):
         head, tail = ntpath.split(texture_filename)
         root, ext = ntpath.splitext(tail)
         # for linux: make paths case insensitive by converting to lower case
-        head = head.lower()
-        root = root.lower()
+        head = head.lower().decode('utf8')
+        root = root.lower().decode('utf8')
         # XXX following is disabled because not all textures in Bully
         # XXX actually have this form; use "-a textures" for this game
         # make relative path for Bully SE


### PR DESCRIPTION
@niftools/pyffi-reviewer 

# Overview
Fixes three issues (primarily exceptions, and errors) that I found when attempting to use toaster on Windows 10 with Python 3.7.

## Fixes Known Issues
Two exceptions in `spells/nif/dump.py` and adds full traces to error logging so these issues are easier to track down when submitted in future issues.

## Documentation
N/A

## Testing
N/A

### Manual
N/A

### Automated
N/A

## Additional Information
I was attempting to dump the textures from Bully: Scholarship Edition when they were encountered. Be aware that I used #68 as a base for testing these changes, and I would suggest merging that PR since this verifies that it's working for at least one additional title.
